### PR TITLE
feat(azure): add pause between cluster creation and resource detection

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -38,3 +38,21 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:e891458c7a61e5b964e09616f1a4f87d0471feae1ec04cc51776e7dec1a3abce",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.7.2"
+  hashes = [
+    "h1:YYLAfhMFP5nhV2iZPslqsLkZN+6sZo7gMJW7pLcLfM8=",
+    "zh:0bbe0158c2a9e3f5be911b7e94477586110c51746bb13d102054f22754565bda",
+    "zh:3250af7fd49b8aaf2ccc895588af05197d886e38b727e3ba33bcbb8cc96ad34d",
+    "zh:35e4de0437f4fa9c1ad69aaf8136413be2369ea607d78e04bb68dc66a6a520b8",
+    "zh:369756417a6272e79cad31eb2c82c202f6a4b6e4204a893f656644ba9e149fa2",
+    "zh:390370f1179d89b33c3a0731691e772d5450a7d59fc66671ec625e201db74aa2",
+    "zh:3d12ac905259d225c685bc42e5507ed0fbdaa5a09c30dce7c1932d908df857f7",
+    "zh:75f63e5e1c68e6c5bccba4568c3564e2774eb3a7a19189eb8e2b6e0d58c8f8cc",
+    "zh:7c22a2078a608e3e0278c4cbc9c483909062ebd1843bddaf8f176346c6d378b1",
+    "zh:7cfb3c02f78f0060d59c757c4726ab45a962ce4a9cf4833beca704a1020785bd",
+    "zh:a0325917f47c28a2ed088dedcea0d9520d91b264e63cc667fe4336ac993c0c11",
+    "zh:c181551d4c0a40b52e236f1755cc340aeca0fb5dcfd08b3b1c393a7667d2f327",
+  ]
+}

--- a/infrastructure/azure/kubernetes.tf
+++ b/infrastructure/azure/kubernetes.tf
@@ -63,6 +63,17 @@ resource "azurerm_kubernetes_cluster_node_pool" "pools" {
   vnet_subnet_id       = azurerm_subnet.network.id
 }
 
+resource "time_sleep" "wait_2_mins" {
+  count = var.enable_airgapped ? 1 : 0
+
+  create_duration = "2m"
+
+  depends_on = [
+    azurerm_kubernetes_cluster.k8s,
+    azurerm_kubernetes_cluster_node_pool.pools
+  ]
+}
+
 data "azurerm_resources" "k8s" {
   count = var.enable_airgapped ? 1 : 0
 
@@ -70,8 +81,7 @@ data "azurerm_resources" "k8s" {
   type                = "Microsoft.Network/networkSecurityGroups"
 
   depends_on = [
-    azurerm_kubernetes_cluster.k8s,
-    azurerm_kubernetes_cluster_node_pool.pools
+    time_sleep.wait_2_mins
   ]
 }
 


### PR DESCRIPTION
Azure airgap installs require a pause between the resource creation before they're detected by the `data "azurerm_resources"` command